### PR TITLE
Add IncludePath option to sass compiler

### DIFF
--- a/WebCompiler/Compile/SassCompiler.cs
+++ b/WebCompiler/Compile/SassCompiler.cs
@@ -57,6 +57,7 @@ namespace WebCompiler.Compile
             {
                 var compile_result = LibSassHost.SassCompiler.CompileFile(file, tmp_output_file, file, new CompilationOptions
                 {
+                    IncludePaths = settings.IncludePath != null ? new List<string> { settings.IncludePath } : null,
                     IndentType = settings.IndentType,
                     IndentWidth = settings.IndentWidth,
                     LineFeedType = settings.LineFeed,


### PR DESCRIPTION
Fix the configuration that was not forwarded to sass for the include path option.