### PR TITLE
Fix #51 to also split dependent files string on newlines

### DIFF
--- a/WebCompiler/Compile/SassCompiler.cs
+++ b/WebCompiler/Compile/SassCompiler.cs
@@ -146,7 +146,7 @@ namespace WebCompiler.Compile
         {
             var url = match.Groups["url"].Value.Replace("'", "\"").Replace("(", "").Replace(")", "").Replace(";", "").Trim();
 
-            foreach (var name in url.Split(new[] { "\"," }, StringSplitOptions.RemoveEmptyEntries))
+            foreach (var name in url.Split(new[] { "\",", "\n" }, StringSplitOptions.RemoveEmptyEntries))
             {
                 var value = name.Replace("\"", "").Replace('/', Path.DirectorySeparatorChar).Trim();
 


### PR DESCRIPTION
Update to SassCompiler.cs. In the case of an inline comment in an import line, splitting the string only by `",` will inadvertently skip over the files listed after the comment. So we shall split by newlines as well.