### PR TITLE
IgnoreFolder now supports Trailing Slash and Ignoring Sub Folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ As a benefit, this implementation is cross-platform (x64 linux/win are tested, p
 
 #### Changes in version 3.2.Y
 
-Supports excluding certain files and folders when using recursive mode
+Supports excluding certain files and folders (including subdirectories where * wildcard is specified) when using recursive mode
 Simply add the following to CompilerSettings.json:
 
 ```json
   "CompilerSettings": {
-     "IgnoreFolders": ["./wwwroot/", "./bin/", "./obj/"],
+     "IgnoreFolders": ["./wwwroot/*", "./bin/*", "./obj/*", "./sass/"],
      "IgnoreFiles": ["./sass/_variables.scss"]
   }
 ```

--- a/Tests_WebCompiler/TestCases/Scss/IgnoreFolder/SubFolder/test.scss
+++ b/Tests_WebCompiler/TestCases/Scss/IgnoreFolder/SubFolder/test.scss
@@ -1,0 +1,6 @@
+﻿html {
+  font-family: sans-serif;
+  line-height: 1.15;
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: transparent
+}

--- a/Tests_WebCompiler/TestCases/Scss/IgnoreFolderAndSubFolders/SubFolder1/test.scss
+++ b/Tests_WebCompiler/TestCases/Scss/IgnoreFolderAndSubFolders/SubFolder1/test.scss
@@ -1,0 +1,6 @@
+﻿html {
+  font-family: sans-serif;
+  line-height: 1.15;
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: transparent
+}

--- a/Tests_WebCompiler/TestCases/Scss/IgnoreFolderAndSubFolders/SubFolder2/test.scss
+++ b/Tests_WebCompiler/TestCases/Scss/IgnoreFolderAndSubFolders/SubFolder2/test.scss
@@ -1,0 +1,6 @@
+﻿html {
+  font-family: sans-serif;
+  line-height: 1.15;
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: transparent
+}

--- a/Tests_WebCompiler/TestCases/Scss/IgnoreFolderAndSubFolders/globalVariables.scss
+++ b/Tests_WebCompiler/TestCases/Scss/IgnoreFolderAndSubFolders/globalVariables.scss
@@ -1,0 +1,1 @@
+﻿$my-special-background-color: purple;

--- a/Tests_WebCompiler/WholeProgramTests.cs
+++ b/Tests_WebCompiler/WholeProgramTests.cs
@@ -453,6 +453,7 @@ namespace Tests_WebCompiler
             };
             output_files = new List<string>
             {
+                "../../../TestCases/Scss/IgnoreFolder/SubFolder/test.css",
                 "../../../TestCases/Scss/site.css",
                 "../../../TestCases/Scss/test.css",
                 "../../../TestCases/Scss/sub/foo.css",
@@ -462,6 +463,9 @@ namespace Tests_WebCompiler
             {
                 // suppressed by IgnoreFolders
                 "../../../TestCases/Scss/IgnoreFolder/globalVariables.css",
+                "../../../TestCases/Scss/IgnoreFolderAndSubFolders/globalVariables.css",
+                "../../../TestCases/Scss/IgnoreFolderAndSubFolders/SubFolder1/test.css",
+                "../../../TestCases/Scss/IgnoreFolderAndSubFolders/SubFolder2/test.css",
                 // suppressed by IgnoreFiles
                 "../../../TestCases/Scss/error.css",
                 "../../../TestCases/Scss/globalVariables.css",
@@ -485,7 +489,8 @@ namespace Tests_WebCompiler
   },
   ""CompilerSettings"": {
     ""IgnoreFolders"": [
-        ""./IgnoreFolder""
+        ""./IgnoreFolder/"",
+        ""./IgnoreFolderAndSubFolders/*""
     ],
     ""IgnoreFiles"": [
         ""./error.scss"",

--- a/WebCompiler/Compile/Compilers.cs
+++ b/WebCompiler/Compile/Compilers.cs
@@ -90,10 +90,47 @@ namespace WebCompiler.Compile
             if(ignorefolders.Count > 0)
             {
                 var pathForComparison = Path.GetFullPath(Path.GetDirectoryName(file));
+                
+                if (!Path.EndsInDirectorySeparator(pathForComparison))
+                {
+                    pathForComparison += Path.DirectorySeparatorChar;
+                }
+                
                 foreach (var ignoreFolder in ignorefolders)
                 {
-                    var ignorePathForComparison = Path.GetFullPath(Path.Combine(this.base_path, ignoreFolder));
-                    if (string.Equals(pathForComparison, ignorePathForComparison, StringComparison.OrdinalIgnoreCase)) return true;
+                    var ignoreSubDirectories = ignoreFolder.EndsWith("*");
+                    if (ignoreSubDirectories)
+                    {
+                        var ignorePathForComparison = Path.GetFullPath(Path.Combine(this.base_path, ignoreFolder.TrimEnd('*')));
+                        
+                        if (!Path.EndsInDirectorySeparator(ignorePathForComparison))
+                        {
+                            ignorePathForComparison += Path.DirectorySeparatorChar;
+                        }
+                        
+                        var underneathIgnoreFolder = pathForComparison.ToUpperInvariant()
+                            .StartsWith(ignorePathForComparison.ToUpperInvariant());
+                        
+                        if (underneathIgnoreFolder)
+                        {
+                            return true;
+                        }
+                    }
+                    else
+                    {
+                        var ignorePathForComparison = Path.GetFullPath(Path.Combine(this.base_path, ignoreFolder));
+
+                        if (!Path.EndsInDirectorySeparator(ignorePathForComparison))
+                        {
+                            ignorePathForComparison += Path.DirectorySeparatorChar;
+                        }
+                        
+                        if (string.Equals(pathForComparison, ignorePathForComparison,
+                                StringComparison.OrdinalIgnoreCase))
+                        {
+                            return true;
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
This PR corrects a mistake in #53 whereby the README.MD specified to have a trailing / but the Unit Test did not (which passes) and in addition allows support to exclude sub folders by specifying * wildcard (this is a quick implementation - we can consider using [File Globbing support](https://docs.microsoft.com/en-us/dotnet/core/extensions/file-globbing) in future 😅).

```
Test run for /workspaces/WebCompiler/Tests_WebCompiler/bin/Debug/net6.0/Tests_WebCompiler.dll (.NETCoreApp,Version=v6.0)
Microsoft (R) Test Execution Command Line Tool Version 17.0.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:    50, Skipped:     0, Total:    50, Duration: 13 s - /workspaces/WebCompiler/Tests_WebCompiler/bin/Debug/net6.0/Tests_WebCompiler.dll (net6.0)
```