### PR TITLE
Add File Globbing Support for Ignore Files/Folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ As a benefit, this implementation is cross-platform (x64 linux/win are tested, p
 
 #### Changes in version 3.2.Y
 
-Supports excluding certain files and folders when using recursive mode
+Supports excluding certain files and folders (nb. Sub folders must be specified specifically if wanting to be ignored) when using recursive mode
 Simply add the following to CompilerSettings.json:
 
 ```json
   "CompilerSettings": {
-     "IgnoreFolders": ["./wwwroot/", "./bin/", "./obj/"],
+     "IgnoreFolders": ["./wwwroot/", "./bin/", "./obj/", "./wwwroot/sass/"],
      "IgnoreFiles": ["./sass/_variables.scss"]
-  }
+  }~~~~
 ```
 
 #### Changes in version 3.1.Y

--- a/README.md
+++ b/README.md
@@ -23,6 +23,17 @@ As a benefit, this implementation is cross-platform (x64 linux/win are tested, p
 
 ### Changelog
 
+#### Changes in version 3.3.Y
+
+*Breaking Change / Warning*: This change removes the key of IgnoreFolders and IgnoreFiles per 3.2.Y and in favour of an "Ignore" key with support for [File Globbing support](https://docs.microsoft.com/en-us/dotnet/core/extensions/file-globbing).
+Simply add the following to CompilerSettings.json:
+
+```json
+  "CompilerSettings": {
+     "Ignore": [ "wwwroot/*.scss", "wwwroot/css/specific-file.scss", "wwwroot/_lib/**/*.scss", "bin/**/*", "obj/**/*" ],
+  }
+```
+
 #### Changes in version 3.2.Y
 
 Supports excluding certain files and folders (nb. Sub folders must be specified specifically if wanting to be ignored) when using recursive mode
@@ -32,7 +43,7 @@ Simply add the following to CompilerSettings.json:
   "CompilerSettings": {
      "IgnoreFolders": ["./wwwroot/", "./bin/", "./obj/", "./wwwroot/sass/"],
      "IgnoreFiles": ["./sass/_variables.scss"]
-  }~~~~
+  }
 ```
 
 #### Changes in version 3.1.Y

--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@ As a benefit, this implementation is cross-platform (x64 linux/win are tested, p
 #### Changes in version 3.3.Y
 
 *Breaking Change / Warning*: This change removes the key of IgnoreFolders and IgnoreFiles per 3.2.Y and in favour of an "Ignore" key with support for [File Globbing support](https://docs.microsoft.com/en-us/dotnet/core/extensions/file-globbing).
+
+If no Ignore value is defined in the CompilerSettings.json then **/_*.* (files prefixed with _) will be ignored.
+If you wish to continue this behaviour and also ignore other patterns, ensure to also include this pattern.
+
 Simply add the following to CompilerSettings.json:
 
 ```json
   "CompilerSettings": {
-     "Ignore": [ "wwwroot/*.scss", "wwwroot/css/specific-file.scss", "wwwroot/_lib/**/*.scss", "bin/**/*", "obj/**/*" ],
+     "Ignore": [ "**/_*.*", "wwwroot/*.scss", "wwwroot/css/specific-file.scss", "wwwroot/_lib/**/*.scss", "bin/**/*", "obj/**/*" ],
   }
 ```
 
@@ -370,8 +374,9 @@ This project is just starting. You can help in many different ways:
 
 `Excubo.WebCompiler` depends on nuget packages for the compilation tasks:
 
-| Language | Library |
+| Language | Library | Comments
 |----------|---------|
 | Sass     | [LibSassHost](https://github.com/Taritsyn/LibSassHost) |
+| Sass     | [DartSassHost](https://github.com/Taritsyn/DartSassHost) | WebCompiler 3.X.Y+
 | Autoprefix | [AutoprefixHost](https://github.com/Taritsyn/AutoprefixerHost) |
 | CSS/JS   | [NUglify](https://github.com/xoofx/NUglify) | 

--- a/Tests_WebCompiler/TestCases/Scss/IgnoreFolder/SubFolder/test.scss
+++ b/Tests_WebCompiler/TestCases/Scss/IgnoreFolder/SubFolder/test.scss
@@ -1,0 +1,6 @@
+﻿html {
+  font-family: sans-serif;
+  line-height: 1.15;
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: transparent
+}

--- a/Tests_WebCompiler/TestCases/Scss/IgnoreFolder2/SubFolder/test.scss
+++ b/Tests_WebCompiler/TestCases/Scss/IgnoreFolder2/SubFolder/test.scss
@@ -1,0 +1,6 @@
+﻿html {
+  font-family: sans-serif;
+  line-height: 1.15;
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: transparent
+}

--- a/Tests_WebCompiler/TestCases/Scss/IgnoreFolder2/globalVariables.scss
+++ b/Tests_WebCompiler/TestCases/Scss/IgnoreFolder2/globalVariables.scss
@@ -1,0 +1,1 @@
+﻿$my-special-background-color: purple;

--- a/Tests_WebCompiler/TestCases/Scss/IgnoreFolderAndSubFolders/SubFolder1/test.scss
+++ b/Tests_WebCompiler/TestCases/Scss/IgnoreFolderAndSubFolders/SubFolder1/test.scss
@@ -1,0 +1,6 @@
+﻿html {
+  font-family: sans-serif;
+  line-height: 1.15;
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: transparent
+}

--- a/Tests_WebCompiler/TestCases/Scss/IgnoreFolderAndSubFolders/SubFolder2/test.scss
+++ b/Tests_WebCompiler/TestCases/Scss/IgnoreFolderAndSubFolders/SubFolder2/test.scss
@@ -1,0 +1,6 @@
+﻿html {
+  font-family: sans-serif;
+  line-height: 1.15;
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: transparent
+}

--- a/Tests_WebCompiler/TestCases/Scss/IgnoreFolderAndSubFolders/globalVariables.scss
+++ b/Tests_WebCompiler/TestCases/Scss/IgnoreFolderAndSubFolders/globalVariables.scss
@@ -1,0 +1,1 @@
+﻿$my-special-background-color: purple;

--- a/Tests_WebCompiler/WholeProgramTests.cs
+++ b/Tests_WebCompiler/WholeProgramTests.cs
@@ -461,14 +461,13 @@ namespace Tests_WebCompiler
             };
             var non_output_files = new List<string>
             {
-                // suppressed by Ignore
+                // suppressed by Ignore Globs
                 "../../../TestCases/Scss/IgnoreFolder/globalVariables.css",
                 "../../../TestCases/Scss/IgnoreFolder2/globalVariables.css",
                 "../../../TestCases/Scss/IgnoreFolder2/SubFolder/test.css",
                 "../../../TestCases/Scss/IgnoreFolderAndSubFolders/globalVariables.css",
                 "../../../TestCases/Scss/IgnoreFolderAndSubFolders/SubFolder1/test.css",
                 "../../../TestCases/Scss/IgnoreFolderAndSubFolders/SubFolder2/test.css",
-                // suppressed by IgnoreFiles
                 "../../../TestCases/Scss/error.css",
                 "../../../TestCases/Scss/globalVariables.css",
                 // supressed by config: no gzip and no minification

--- a/Tests_WebCompiler/WholeProgramTests.cs
+++ b/Tests_WebCompiler/WholeProgramTests.cs
@@ -453,6 +453,7 @@ namespace Tests_WebCompiler
             };
             output_files = new List<string>
             {
+                "../../../TestCases/Scss/IgnoreFolder/SubFolder/test.css",
                 "../../../TestCases/Scss/site.css",
                 "../../../TestCases/Scss/test.css",
                 "../../../TestCases/Scss/sub/foo.css",
@@ -462,6 +463,9 @@ namespace Tests_WebCompiler
             {
                 // suppressed by IgnoreFolders
                 "../../../TestCases/Scss/IgnoreFolder/globalVariables.css",
+                "../../../TestCases/Scss/IgnoreFolderAndSubFolders/globalVariables.css",
+                "../../../TestCases/Scss/IgnoreFolderAndSubFolders/SubFolder1/test.css",
+                "../../../TestCases/Scss/IgnoreFolderAndSubFolders/SubFolder2/test.css",
                 // suppressed by IgnoreFiles
                 "../../../TestCases/Scss/error.css",
                 "../../../TestCases/Scss/globalVariables.css",
@@ -485,7 +489,10 @@ namespace Tests_WebCompiler
   },
   ""CompilerSettings"": {
     ""IgnoreFolders"": [
-        ""./IgnoreFolder""
+        ""./IgnoreFolder/"",
+        ""./IgnoreFolderAndSubFolders/"",
+        ""./IgnoreFolderAndSubFolders/SubFolder1/"",
+        ""./IgnoreFolderAndSubFolders/SubFolder2/""
     ],
     ""IgnoreFiles"": [
         ""./error.scss"",

--- a/Tests_WebCompiler/WholeProgramTests.cs
+++ b/Tests_WebCompiler/WholeProgramTests.cs
@@ -461,8 +461,10 @@ namespace Tests_WebCompiler
             };
             var non_output_files = new List<string>
             {
-                // suppressed by IgnoreFolders
+                // suppressed by Ignore
                 "../../../TestCases/Scss/IgnoreFolder/globalVariables.css",
+                "../../../TestCases/Scss/IgnoreFolder2/globalVariables.css",
+                "../../../TestCases/Scss/IgnoreFolder2/SubFolder/test.css",
                 "../../../TestCases/Scss/IgnoreFolderAndSubFolders/globalVariables.css",
                 "../../../TestCases/Scss/IgnoreFolderAndSubFolders/SubFolder1/test.css",
                 "../../../TestCases/Scss/IgnoreFolderAndSubFolders/SubFolder2/test.css",
@@ -488,15 +490,12 @@ namespace Tests_WebCompiler
     ""Enabled"": false
   },
   ""CompilerSettings"": {
-    ""IgnoreFolders"": [
-        ""./IgnoreFolder/"",
-        ""./IgnoreFolderAndSubFolders/"",
-        ""./IgnoreFolderAndSubFolders/SubFolder1/"",
-        ""./IgnoreFolderAndSubFolders/SubFolder2/""
-    ],
-    ""IgnoreFiles"": [
-        ""./error.scss"",
-        ""globalVariables.scss""
+    ""Ignore"": [
+        ""IgnoreFolder/*.scss"",
+        ""IgnoreFolder2/**/*"",
+        ""IgnoreFolderAndSubFolders/**/*.scss"",
+        ""error.scss"",
+        ""globalVar*.scss""
     ],
     ""Sass"": {
       ""IndentType"": ""Space"",

--- a/WebCompiler/Compile/Compilers.cs
+++ b/WebCompiler/Compile/Compilers.cs
@@ -16,14 +16,10 @@ namespace WebCompiler.Compile
         private readonly Compiler place;
         private readonly Compiler cleanup;
         private readonly Compiler autoprefix;
-        private readonly List<string> ignorefiles;
-        private readonly List<string> ignorefolders;
         private readonly string base_path;
 
         public Compilers(Config config, string base_path)
         {
-            ignorefiles = config.CompilerSettings.IgnoreFiles;
-            ignorefolders = config.CompilerSettings.IgnoreFolders;
             this.base_path = base_path;
 
             sass = config.Autoprefix.Enabled ? new SassCompiler(config.CompilerSettings.Sass, config.Autoprefix) : new SassCompiler(config.CompilerSettings.Sass);
@@ -37,11 +33,6 @@ namespace WebCompiler.Compile
         private static CompilationStep Compile(string file) => new CompilationStep(file);
         public CompilationStep TryCompile(string file)
         {
-            if(SkipProcessingThisFile(file, base_path))
-            {
-                return new CompilationStep(file);
-            }
-            
             switch (Path.GetExtension(file)?.ToUpperInvariant())
             {
                 case ".SCSS":
@@ -83,47 +74,6 @@ namespace WebCompiler.Compile
                 default:
                     return Compile(file).With(terminating_compiler);
             }
-        }
-
-        private bool SkipProcessingThisFile(string file, string base_path)
-        {
-            if(ignorefolders.Count > 0)
-            {
-                var pathForComparison = Path.GetFullPath(Path.GetDirectoryName(file));
-                
-                if (!Path.EndsInDirectorySeparator(pathForComparison))
-                {
-                    pathForComparison += Path.DirectorySeparatorChar;
-                }
-                
-                foreach (var ignoreFolder in ignorefolders)
-                {
-                    var ignorePathForComparison = Path.GetFullPath(Path.Combine(this.base_path, ignoreFolder));
-
-                    if (!Path.EndsInDirectorySeparator(ignorePathForComparison))
-                    {
-                        ignorePathForComparison += Path.DirectorySeparatorChar;
-                    }
-                    
-                    if (string.Equals(pathForComparison, ignorePathForComparison,
-                            StringComparison.OrdinalIgnoreCase))
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            if(ignorefiles.Count > 0)
-            {
-                var absoluteFilePath = Path.GetFullPath(file);
-                foreach(var ignoreFile in ignorefiles)
-                {
-                    var ignoreFileNameForComparison = Path.GetFullPath(Path.Combine(this.base_path, ignoreFile));
-                    if (string.Equals(absoluteFilePath, ignoreFileNameForComparison, StringComparison.OrdinalIgnoreCase)) return true;
-                }
-            }
-
-            return false;
         }
     }
 }

--- a/WebCompiler/Compile/Compilers.cs
+++ b/WebCompiler/Compile/Compilers.cs
@@ -90,10 +90,26 @@ namespace WebCompiler.Compile
             if(ignorefolders.Count > 0)
             {
                 var pathForComparison = Path.GetFullPath(Path.GetDirectoryName(file));
+                
+                if (!Path.EndsInDirectorySeparator(pathForComparison))
+                {
+                    pathForComparison += Path.DirectorySeparatorChar;
+                }
+                
                 foreach (var ignoreFolder in ignorefolders)
                 {
                     var ignorePathForComparison = Path.GetFullPath(Path.Combine(this.base_path, ignoreFolder));
-                    if (string.Equals(pathForComparison, ignorePathForComparison, StringComparison.OrdinalIgnoreCase)) return true;
+
+                    if (!Path.EndsInDirectorySeparator(ignorePathForComparison))
+                    {
+                        ignorePathForComparison += Path.DirectorySeparatorChar;
+                    }
+                    
+                    if (string.Equals(pathForComparison, ignorePathForComparison,
+                            StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
                 }
             }
 

--- a/WebCompiler/Configuration/CompilerSettingsCollection.cs
+++ b/WebCompiler/Configuration/CompilerSettingsCollection.cs
@@ -6,7 +6,6 @@ namespace WebCompiler.Configuration
     public class CompilerSettingsCollection
     {
         public SassSettings Sass { get; set; } = new SassSettings();
-        public List<string> IgnoreFolders { get; set; } = new List<string>();
-        public List<string> IgnoreFiles { get; set; } = new List<string>();
+        public List<string> Ignore { get; set; } = new List<string>();
     }
 }

--- a/WebCompiler/Configuration/CompilerSettingsCollection.cs
+++ b/WebCompiler/Configuration/CompilerSettingsCollection.cs
@@ -6,6 +6,18 @@ namespace WebCompiler.Configuration
     public class CompilerSettingsCollection
     {
         public SassSettings Sass { get; set; } = new SassSettings();
-        public List<string> Ignore { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Ignore Files or Folders matching certain patterns
+        /// <see cref="https://docs.microsoft.com/en-us/dotnet/core/extensions/file-globbing" />
+        /// 
+        /// If no pattern(s) are specified, by default **/_*.* will be applied to ignore any files
+        /// prefixed with _
+        /// </summary>
+        /// <typeparam name="string"></typeparam>
+        /// <returns></returns>
+        public List<string> Ignore { get; set; } = new List<string>(){IgnoreUnderscorePrefixedFilesGlobPattern};
+
+        private const string IgnoreUnderscorePrefixedFilesGlobPattern = "**/_*.*";
     }
 }

--- a/WebCompiler/Helpers/FileFolderHelpers.cs
+++ b/WebCompiler/Helpers/FileFolderHelpers.cs
@@ -9,8 +9,6 @@ namespace WebCompiler.Helpers
     {
         public static IEnumerable<string> Recurse(string directory, List<string> ignoreGlobs)
         {
-            ignoreGlobs.Add("**/_*.*"); // Also Ignore all files that start with _
-
             var matcher = new Matcher();
             matcher.AddInclude("**/*");
             matcher.AddExcludePatterns(ignoreGlobs);

--- a/WebCompiler/Helpers/FileFolderHelpers.cs
+++ b/WebCompiler/Helpers/FileFolderHelpers.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.FileSystemGlobbing;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -6,21 +7,16 @@ namespace WebCompiler.Helpers
 {
     public static class FileFolderHelpers
     {
-        public static IEnumerable<string> Recurse(string directory)
+        public static IEnumerable<string> Recurse(string directory, List<string> ignoreGlobs)
         {
-            foreach (var file in Directory.GetFiles(directory))
+            ignoreGlobs.Add("**/_*.*"); // Also Ignore all files that start with _
+
+            var matcher = new Matcher();
+            matcher.AddInclude("**/*");
+            matcher.AddExcludePatterns(ignoreGlobs);
+            foreach (string file in matcher.GetResultsInFullPath(directory))
             {
-                if (!Path.GetFileName(file).StartsWith('_'))
-                {
-                    yield return file;
-                }
-            }
-            foreach (var subdir in Directory.GetDirectories(directory))
-            {
-                foreach (var file in Recurse(subdir))
-                {
-                    yield return file;
-                }
+                yield return file;
             }
         }
     }

--- a/WebCompiler/Program.cs
+++ b/WebCompiler/Program.cs
@@ -208,7 +208,7 @@ File format to specify compiler configuration (-c|--config):
                     {
                         Console.WriteLine($"{item} is a directory, but option -r is not used. Ignoring {item} and all items in it.");
                     }
-                    foreach (var file in Helpers.FileFolderHelpers.Recurse(item))
+                    foreach (var file in Helpers.FileFolderHelpers.Recurse(item, config.CompilerSettings.Ignore))
                     {
                         var result = compilers.TryCompile(file);
                         if (result.Errors != null)

--- a/WebCompiler/WebCompiler.csproj
+++ b/WebCompiler/WebCompiler.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-arm64" Version="7.2.0" />
     <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-x64" Version="7.2.0" />
     <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.2.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
     <PackageReference Include="NUglify" Version="1.17.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR adds file globbing support for Ignoring Files/Folders as discussed in https://github.com/excubo-ag/WebCompiler/pull/58#issue-1099746053.

Note: This PR should be either reviewed/merged after #58 merges (as was based off the same branch and includes _Support Trailing Slash in IgnoreFolder variables_ commit or #58 abandoned in favour of this PR which has both commits.

```
@kaizen365 ➜ /workspaces/WebCompiler (feature/ignorefolder-globbing ✗) $ dotnet test
  Determining projects to restore...
  All projects are up-to-date for restore.
  WebCompiler -> /workspaces/WebCompiler/WebCompiler/bin/Debug/net6.0/Excubo.WebCompiler.dll
  Tests_WebCompiler -> /workspaces/WebCompiler/Tests_WebCompiler/bin/Debug/net6.0/Tests_WebCompiler.dll
Test run for /workspaces/WebCompiler/Tests_WebCompiler/bin/Debug/net6.0/Tests_WebCompiler.dll (.NETCoreApp,Version=v6.0)
Microsoft (R) Test Execution Command Line Tool Version 17.0.0
Copyright (c) Microsoft Corporation.  All rights reserved.

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:    50, Skipped:     0, Total:    50, Duration: 13 s - /workspaces/WebCompiler/Tests_WebCompiler/bin/Debug/net6.0/Tests_WebCompiler.dll (net6.0)
```