### PR TITLE
Add omit source map url mapping to sass settings

### DIFF
--- a/Tests_WebCompiler/SassOmitSourceMapUrlTests.cs
+++ b/Tests_WebCompiler/SassOmitSourceMapUrlTests.cs
@@ -10,13 +10,14 @@ namespace Tests_WebCompiler
 {
     public class SassOmitSourceMapUrlTests : TestsBase
     {
-        [Test]
-        public void TestOmitSourceMapUrlTrue()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestOmitSourceMapUrl(bool omitSourceMapUrl)
         {
-            // Setup pipeline with OmitSourceMapUrl = true
+            // Setup pipeline with OmitSourceMapUrl parameter
             pipeline = (file) =>
                     new CompilationStep(file)
-                           .With(new SassCompiler(new SassSettings { SourceMap = true, OmitSourceMapUrl = true }));
+                           .With(new SassCompiler(new SassSettings { SourceMap = true, OmitSourceMapUrl = omitSourceMapUrl }));
             input = "../../../TestCases/Scss/test.scss";
             output_files = new List<string> { "../../../TestCases/Scss/test.css" };
             
@@ -35,39 +36,17 @@ namespace Tests_WebCompiler
             // Read the CSS content
             var cssContent = File.ReadAllText(cssFile);
             
-            // When OmitSourceMapUrl is true, the sourceMappingURL comment should not be present
-            Assert.That(cssContent.Contains("sourceMappingURL"), Is.False, 
-                "CSS file should not contain sourceMappingURL comment when OmitSourceMapUrl is true");
-        }
-
-        [Test]
-        public void TestOmitSourceMapUrlFalse()
-        {
-            // Setup pipeline with OmitSourceMapUrl = false (default)
-            pipeline = (file) =>
-                    new CompilationStep(file)
-                           .With(new SassCompiler(new SassSettings { SourceMap = true, OmitSourceMapUrl = false }));
-            input = "../../../TestCases/Scss/test.scss";
-            output_files = new List<string> { "../../../TestCases/Scss/test.css" };
-            
-            DeleteOutputFiles();
-            
-            // Process the file
-            CompilationStep result = null;
-            Assert.DoesNotThrow(() => result = pipeline(input), "Compiling should not result in exception");
-            Assert.That(result, Is.Not.Null, "Compilation result may not be null");
-            Assert.That(result.Errors == null || !result.Errors.Any(), Is.True, "Compilation should not result in error");
-            
-            // Verify the CSS file was created
-            var cssFile = "../../../TestCases/Scss/test.css";
-            Assert.That(File.Exists(cssFile), Is.True, "CSS file should be created");
-            
-            // Read the CSS content
-            var cssContent = File.ReadAllText(cssFile);
-            
-            // When OmitSourceMapUrl is false, the sourceMappingURL comment should be present
-            Assert.That(cssContent.Contains("sourceMappingURL"), Is.True, 
-                "CSS file should contain sourceMappingURL comment when OmitSourceMapUrl is false");
+            // Verify sourceMappingURL presence based on the parameter
+            if (omitSourceMapUrl)
+            {
+                Assert.That(cssContent.Contains("sourceMappingURL"), Is.False, 
+                    "CSS file should not contain sourceMappingURL comment when OmitSourceMapUrl is true");
+            }
+            else
+            {
+                Assert.That(cssContent.Contains("sourceMappingURL"), Is.True, 
+                    "CSS file should contain sourceMappingURL comment when OmitSourceMapUrl is false");
+            }
         }
     }
 }

--- a/Tests_WebCompiler/SassOmitSourceMapUrlTests.cs
+++ b/Tests_WebCompiler/SassOmitSourceMapUrlTests.cs
@@ -1,0 +1,73 @@
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using WebCompiler.Compile;
+using WebCompiler.Configuration;
+using WebCompiler.Configuration.Settings;
+
+namespace Tests_WebCompiler
+{
+    public class SassOmitSourceMapUrlTests : TestsBase
+    {
+        [Test]
+        public void TestOmitSourceMapUrlTrue()
+        {
+            // Setup pipeline with OmitSourceMapUrl = true
+            pipeline = (file) =>
+                    new CompilationStep(file)
+                           .With(new SassCompiler(new SassSettings { SourceMap = true, OmitSourceMapUrl = true }));
+            input = "../../../TestCases/Scss/test.scss";
+            output_files = new List<string> { "../../../TestCases/Scss/test.css" };
+            
+            DeleteOutputFiles();
+            
+            // Process the file
+            CompilationStep result = null;
+            Assert.DoesNotThrow(() => result = pipeline(input), "Compiling should not result in exception");
+            Assert.That(result, Is.Not.Null, "Compilation result may not be null");
+            Assert.That(result.Errors == null || !result.Errors.Any(), Is.True, "Compilation should not result in error");
+            
+            // Verify the CSS file was created
+            var cssFile = "../../../TestCases/Scss/test.css";
+            Assert.That(File.Exists(cssFile), Is.True, "CSS file should be created");
+            
+            // Read the CSS content
+            var cssContent = File.ReadAllText(cssFile);
+            
+            // When OmitSourceMapUrl is true, the sourceMappingURL comment should not be present
+            Assert.That(cssContent.Contains("sourceMappingURL"), Is.False, 
+                "CSS file should not contain sourceMappingURL comment when OmitSourceMapUrl is true");
+        }
+
+        [Test]
+        public void TestOmitSourceMapUrlFalse()
+        {
+            // Setup pipeline with OmitSourceMapUrl = false (default)
+            pipeline = (file) =>
+                    new CompilationStep(file)
+                           .With(new SassCompiler(new SassSettings { SourceMap = true, OmitSourceMapUrl = false }));
+            input = "../../../TestCases/Scss/test.scss";
+            output_files = new List<string> { "../../../TestCases/Scss/test.css" };
+            
+            DeleteOutputFiles();
+            
+            // Process the file
+            CompilationStep result = null;
+            Assert.DoesNotThrow(() => result = pipeline(input), "Compiling should not result in exception");
+            Assert.That(result, Is.Not.Null, "Compilation result may not be null");
+            Assert.That(result.Errors == null || !result.Errors.Any(), Is.True, "Compilation should not result in error");
+            
+            // Verify the CSS file was created
+            var cssFile = "../../../TestCases/Scss/test.css";
+            Assert.That(File.Exists(cssFile), Is.True, "CSS file should be created");
+            
+            // Read the CSS content
+            var cssContent = File.ReadAllText(cssFile);
+            
+            // When OmitSourceMapUrl is false, the sourceMappingURL comment should be present
+            Assert.That(cssContent.Contains("sourceMappingURL"), Is.True, 
+                "CSS file should contain sourceMappingURL comment when OmitSourceMapUrl is false");
+        }
+    }
+}

--- a/WebCompiler/Compile/SassCompiler.cs
+++ b/WebCompiler/Compile/SassCompiler.cs
@@ -61,6 +61,7 @@ namespace WebCompiler.Compile
                     OutputStyle = settings.OutputStyle,
                     SourceMap = settings.SourceMap,
                     InlineSourceMap = settings.SourceMap,
+                    OmitSourceMapUrl = settings.OmitSourceMapUrl,
                 };
                 if (settings.IncludePath != null)
                 {

--- a/WebCompiler/Configuration/Settings/SassSettings.cs
+++ b/WebCompiler/Configuration/Settings/SassSettings.cs
@@ -11,5 +11,6 @@ namespace WebCompiler.Configuration.Settings
         public bool RelativeUrls { get; set; } = true;
         public string? SourceMapRoot { get; set; }
         public LineFeedType LineFeed { get; set; } = LineFeedType.Lf;
+        public bool OmitSourceMapUrl { get; set; } = false;
     }
 }


### PR DESCRIPTION
The motivation is to allow to remove the `sourceMapUrl` from sass compilation output