### PR TITLE
Update a Dart Sass Host to version 2.0.5 and mark obsolete settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,11 +350,8 @@ The default configuration is
   },
   "CompilerSettings": {
     "Sass": {
-      "IndentType": "Space",
-      "IndentWidth": 2,
       "OutputStyle": "Expanded",
       "RelativeUrls": true,
-      "LineFeed": "Lf",
       "SourceMap": false
     }
   },

--- a/WebCompiler/Compile/SassCompiler.cs
+++ b/WebCompiler/Compile/SassCompiler.cs
@@ -55,9 +55,6 @@ namespace WebCompiler.Compile
             {
                 var options = new CompilationOptions
                 {
-                    IndentType = settings.IndentType,
-                    IndentWidth = settings.IndentWidth,
-                    LineFeedType = settings.LineFeed,
                     OutputStyle = settings.OutputStyle,
                     SourceMap = settings.SourceMap,
                     InlineSourceMap = settings.SourceMap,

--- a/WebCompiler/Configuration/Settings/SassSettings.cs
+++ b/WebCompiler/Configuration/Settings/SassSettings.cs
@@ -1,15 +1,20 @@
-﻿using DartSassHost;
+﻿using System;
+
+using DartSassHost;
 
 namespace WebCompiler.Configuration.Settings
 {
     public class SassSettings : BaseCompileSettings
     {
         public string? IncludePath { get; set; }
+        [Obsolete]
         public IndentType IndentType { get; set; } = IndentType.Space;
+        [Obsolete]
         public int IndentWidth { get; set; } = 2;
         public OutputStyle OutputStyle { get; set; } = OutputStyle.Expanded;
         public bool RelativeUrls { get; set; } = true;
         public string? SourceMapRoot { get; set; }
+        [Obsolete]
         public LineFeedType LineFeed { get; set; } = LineFeedType.Lf;
         public bool OmitSourceMapUrl { get; set; } = false;
     }

--- a/WebCompiler/Program.cs
+++ b/WebCompiler/Program.cs
@@ -126,13 +126,9 @@ File format to specify compiler configuration (-c|--config):
         ""compilers"": {
             ""sass"": {
                 ""includePath"": """",
-                ""indentType"": ""space"",
-                ""indentWidth"": 2,
                 ""outputStyle"": ""nested"",
-                ""Precision"": 5,
                 ""relativeUrls"": true,
                 ""sourceMapRoot"": """",
-                ""lineFeed"": """",
                 ""sourceMap"": false
             },
         },

--- a/WebCompiler/WebCompiler.csproj
+++ b/WebCompiler/WebCompiler.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoprefixerHost" Version="3.2.0" />
-    <PackageReference Include="DartSassHost" Version="1.1.1" />
-    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.29.1" />
+    <PackageReference Include="DartSassHost" Version="2.0.5" />
+    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.31.0" />
     <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x86" Version="7.5.0" />
     <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.5.0" />
     <PackageReference Include="Microsoft.ClearScript.V8.Native.win-arm64" Version="7.5.0" />


### PR DESCRIPTION
Hello, Stefan!

Performance has been significantly increased in version 2.X, so I recommend that you update it, as well as its dependencies, to the latest versions. I have marked three Sass settings as deprecated: `IndentType`, `IndentWidth` and `LineFeed`.